### PR TITLE
fix: use coverage directly instead of pytest-cov

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -20,7 +20,7 @@ def test(session):
     """Run all the test using the environment variable of the running machine."""
     session.install(".[test]")
     test_files = session.posargs or ["tests"]
-    session.run("pytest", "--color=yes", "--cov", "--cov-report=xml", *test_files)
+    session.run("coverage", "run", "-m", "pytest", "--color=yes", *test_files)
 
 
 @nox.session(reuse_venv=True, name="dead-fixtures")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,8 @@ dev = [
 ]
 test = [
   "pytest",
+  "coverage",
   "pytest-sugar",
-  "pytest-cov",
   "pytest-deadfixtures"
 ]
 doc = [


### PR DESCRIPTION
Fix #1 

ref: https://stackoverflow.com/questions/62221654/how-to-get-coverage-reporting-when-testing-a-pytest-plugin