### PR TITLE
Fix typo in usage.rst

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -20,7 +20,7 @@ the ``copier.yaml`` file has the following content:
 
    repo_name:
       type: str
-      default": foobar
+      default: foobar
    short_description:
       type: str
       default: Test Project


### PR DESCRIPTION
I think this is a typo?

There are no other quotation marks in the yaml file, and in any case, quotation marks should come in pairs. I think this is probably just a typo.