### PR TITLE
fix: accept all alternative extentions for copier.yaml

### DIFF
--- a/pytest_copie/plugin.py
+++ b/pytest_copie/plugin.py
@@ -60,7 +60,8 @@ class Copie:
         """
         # set the template dir and the associated copier.yaml file
         template_dir = template_dir or self.default_template_dir
-        copier_yaml = template_dir / "copier.yaml"
+        files = template_dir.glob("copier.*")
+        copier_yaml = next(f for f in files if f.suffix in [".yaml", ".yml"])
 
         # create a new output_dir in the test dir based on the counter value
         (output_dir := self.test_dir / f"copie{self.counter:03d}").mkdir()

--- a/pytest_copie/plugin.py
+++ b/pytest_copie/plugin.py
@@ -61,7 +61,10 @@ class Copie:
         # set the template dir and the associated copier.yaml file
         template_dir = template_dir or self.default_template_dir
         files = template_dir.glob("copier.*")
-        copier_yaml = next(f for f in files if f.suffix in [".yaml", ".yml"])
+        try:
+            copier_yaml = next(f for f in files if f.suffix in [".yaml", ".yml"])
+        except StopIteration:
+            raise FileNotFoundError("No copier.yaml configuration file found.")
 
         # create a new output_dir in the test dir based on the counter value
         (output_dir := self.test_dir / f"copie{self.counter:03d}").mkdir()


### PR DESCRIPTION
Fix #50 

I try to detect any "copier" file with a yaml-like extension. My guess is that there should be only one so if multiple exist I take the first one. 

@GenevieveBuckley do you think it's enough to solve the issue you raised? 
