### PR TITLE
Test pytest-copie on a demo template repo as part of test suite

### DIFF
--- a/demo_template/README.rst
+++ b/demo_template/README.rst
@@ -1,0 +1,5 @@
+Demo template
+=============
+
+A demo copier template, including tests with pytest-copie.
+For more details, see `docs/usage.rst`.

--- a/demo_template/copier.yaml
+++ b/demo_template/copier.yaml
@@ -1,0 +1,7 @@
+name:
+  type: str
+  default: foobar
+short_description:
+  type: str
+  default: Test Project
+_subdirectory: template

--- a/demo_template/template/README.rst.jinja
+++ b/demo_template/template/README.rst.jinja
@@ -1,0 +1,4 @@
+{{ name }}
+===============
+
+{{ short_description }}

--- a/demo_template/tests/test_custom_template_fixture.py
+++ b/demo_template/tests/test_custom_template_fixture.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import pytest
+import yaml
+
+
+@pytest.fixture
+def custom_template(tmp_path) -> Path:
+    # Create custom copier template directory and copier.yaml file
+    (template := tmp_path / "copier-template").mkdir()
+    questions = {"custom_name": {"type": "str", "default": "my_default_name"}}
+    (template /"copier.yaml").write_text(yaml.dump(questions))
+    # Create custom subdirectory
+    (repo_dir := template / "custom_template").mkdir()
+    (template /"copier.yaml").write_text(yaml.dump({"_subdirectory": "custom_template"}))
+    # Create custom template text files
+    (repo_dir / "README.rst.jinja").write_text("{{custom_name}}\n")
+
+    return template
+
+
+def test_copie_custom_project(copie, custom_template):
+
+    result = copie.copy(template_dir=custom_template,
+                        extra_answers={"custom_name": "tutu"})
+
+    assert result.project_dir.is_dir()
+    with open(result.project_dir/"README.rst") as f:
+        assert f.readline() == "tutu\n"

--- a/demo_template/tests/test_custom_template_fixture.py
+++ b/demo_template/tests/test_custom_template_fixture.py
@@ -1,17 +1,22 @@
+"""Demo example of how to use pytest-copie with a custom template fixture."""
 from pathlib import Path
+
 import pytest
 import yaml
 
 
 @pytest.fixture
 def custom_template(tmp_path) -> Path:
+    """Generate a custom copier template to use as a pytest fixture."""
     # Create custom copier template directory and copier.yaml file
     (template := tmp_path / "copier-template").mkdir()
     questions = {"custom_name": {"type": "str", "default": "my_default_name"}}
-    (template /"copier.yaml").write_text(yaml.dump(questions))
+    (template / "copier.yaml").write_text(yaml.dump(questions))
     # Create custom subdirectory
     (repo_dir := template / "custom_template").mkdir()
-    (template /"copier.yaml").write_text(yaml.dump({"_subdirectory": "custom_template"}))
+    (template / "copier.yaml").write_text(
+        yaml.dump({"_subdirectory": "custom_template"})
+    )
     # Create custom template text files
     (repo_dir / "README.rst.jinja").write_text("{{custom_name}}\n")
 
@@ -19,10 +24,11 @@ def custom_template(tmp_path) -> Path:
 
 
 def test_copie_custom_project(copie, custom_template):
-
-    result = copie.copy(template_dir=custom_template,
-                        extra_answers={"custom_name": "tutu"})
+    """Test custom copier template fixture using pytest-copie."""
+    result = copie.copy(
+        template_dir=custom_template, extra_answers={"custom_name": "tutu"}
+    )
 
     assert result.project_dir.is_dir()
-    with open(result.project_dir/"README.rst") as f:
+    with open(result.project_dir / "README.rst") as f:
         assert f.readline() == "tutu\n"

--- a/demo_template/tests/test_template.py
+++ b/demo_template/tests/test_template.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+
+def test_template(copie):
+    # This demo copier template is a subdirectory of the main repository
+    # so we hvae to specify the location for pytest.
+    # Users who have `copier.yaml` at the top level of their repository
+    # can delete the template_dir keyword argument here.
+    demo_template_dir = Path(__file__).parent.parent
+
+    result = copie.copy(template_dir=demo_template_dir)
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert result.project_dir.is_dir()
+    with open(result.project_dir/"README.rst") as f:
+        assert f.readline() == "foobar\n"
+
+
+def test_template_with_extra_answers(copie):
+    # This demo copier template is a subdirectory of the main repository
+    # so we hvae to specify the location for pytest.
+    # Users who have `copier.yaml` at the top level of their repository
+    # can delete the template_dir keyword argument here.
+    demo_template_dir = Path(__file__).parent.parent
+
+    result = copie.copy(extra_answers={"name": "helloworld"},
+                        template_dir=demo_template_dir)
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert result.project_dir.is_dir()
+    with open(result.project_dir/"README.rst") as f:
+        assert f.readline() == "helloworld\n"

--- a/demo_template/tests/test_template.py
+++ b/demo_template/tests/test_template.py
@@ -1,9 +1,11 @@
+"""Demo example of how to test a copier template with pytest-copie."""
 from pathlib import Path
 
 
 def test_template(copie):
+    """Test the demo copier template using pytest-copie."""
     # This demo copier template is a subdirectory of the main repository
-    # so we hvae to specify the location for pytest.
+    # so we have to specify the location for pytest.
     # Users who have `copier.yaml` at the top level of their repository
     # can delete the template_dir keyword argument here.
     demo_template_dir = Path(__file__).parent.parent
@@ -13,22 +15,24 @@ def test_template(copie):
     assert result.exit_code == 0
     assert result.exception is None
     assert result.project_dir.is_dir()
-    with open(result.project_dir/"README.rst") as f:
+    with open(result.project_dir / "README.rst") as f:
         assert f.readline() == "foobar\n"
 
 
 def test_template_with_extra_answers(copie):
+    """Test the demo copier template with extra answers using pytest-copie."""
     # This demo copier template is a subdirectory of the main repository
-    # so we hvae to specify the location for pytest.
+    # so we have to specify the location for pytest.
     # Users who have `copier.yaml` at the top level of their repository
     # can delete the template_dir keyword argument here.
     demo_template_dir = Path(__file__).parent.parent
 
-    result = copie.copy(extra_answers={"name": "helloworld"},
-                        template_dir=demo_template_dir)
+    result = copie.copy(
+        extra_answers={"name": "helloworld"}, template_dir=demo_template_dir
+    )
 
     assert result.exit_code == 0
     assert result.exception is None
     assert result.project_dir.is_dir()
-    with open(result.project_dir/"README.rst") as f:
+    with open(result.project_dir / "README.rst") as f:
         assert f.readline() == "helloworld\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ version_files = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = "tests"
+testpaths = ["tests", "demo_template"]
 
 [tool.ruff]
 ignore-init-module-imports = true


### PR DESCRIPTION
This PR adds integration tests for pytest-copie.

The current test suite includes test of the pytest-copie fixture, but currently does not check whether pytest-copie can run on a demo template repository.

This PR adds a `demo_template` folder to the repo, containing the files described in the user example guide at `doc/usage.rst`.  This is then included in the pytest testpaths, so the example tests in the demo template are executed at test time.

**Advantages:** Future changes to pytest-copie will not cause the usage instructions to become incorrect without anyone noticing.
I think it was [this one](https://github.com/12rambau/pytest-copie/pull/41) that caused problems with all the `assert result.projject_dir.name == "foobar"` statements in the user guide, so it has happened before.

**Disadvantages:** There's nothing stopping someone from fixing the tests in the new demo template, but not ALSO making the same changes to `doc/usage.rst`. So, unless the reviewer spots this, it might still be possible for the user instructions to become inaccurate again. Hopefully this will be less likely, though.