### PR TITLE
Ignore errors in teardown process

### DIFF
--- a/pytest_copie/plugin.py
+++ b/pytest_copie/plugin.py
@@ -141,7 +141,7 @@ def copie(request, tmp_path: Path, _copier_config_file: Path) -> Generator:
 
     # don't delete the files at the end of the test if requested
     if not request.config.option.keep_copied_projects:
-        rmtree(test_dir)
+        rmtree(test_dir, ignore_errors=True)
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
Closes https://github.com/12rambau/pytest-copie/issues/55

I understand totally if you don't want to go with the simplest solution here, but I thought I'd open this in case your open to it.

With the current main branch, some users [might run into failing CI jobs, like this](https://github.com/napari/napari-plugin-template/pull/1#issuecomment-1788534594).

With this PR, the worst case scenario is that some test files do not get removed completely from the pytest temp directories. That's not a problem on CI, since there is no persistance of files there. On a local machine, possibly this could become a problem if many hundreds or thousands of tiles built up over time on the disk (but presumably someone would clear the pytest cache at some stage if they needed more disk space). So, potentially annoying in some limited edge cases, but the advantage is that it won't cause the test suite to fail (and not because the tests fail, but because of an error in the teardown process).

