### PR TITLE
fix: remove the cff e process from github action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,8 +15,6 @@ jobs:
           python-version: "3.10"
       - name: Install dependencies
         run: pip install twine build nox
-      - name: update citation date
-        run: nox -s release-date
       - name: Build and publish
         env:
           TWINE_USERNAME: __token__


### PR DESCRIPTION
We removed the .cff file so updating the date is not necessary anymore