### PR TITLE
fix: run coverage before pytest

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -20,7 +20,8 @@ def test(session):
     """Run all the test using the environment variable of the running machine."""
     session.install(".[test]")
     test_files = session.posargs or ["tests", "demo_template"]
-    session.run("pytest", "--color=yes", "--cov", "--cov-report=xml", *test_files)
+    session.run("coverage", "run", "-m", "pytest", "--color=yes", *test_files)
+    session.run("coverage", "xml")
 
 
 @nox.session(reuse_venv=True, name="dead-fixtures")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,8 @@ copie = "pytest_copie.plugin"
 test = [
   "pytest",
   "pytest-sugar",
-  "pytest-cov",
-  "pytest-deadfixtures"
+  "pytest-deadfixtures",
+  "coverage",
 ]
 doc = [
   "sphinx>=6.2.1",


### PR DESCRIPTION
Fix #65 

According to https://stackoverflow.com/questions/62221654/how-to-get-coverage-reporting-when-testing-a-pytest-plugin the plugins themselves cannot be tested with `pytest-cov` as the coverage session needs to start before the plugins are actually loaded. 

Following the instructions of the answer I changed the noxfile file content to launch coverage manually and export the report in xml. 