### PR TITLE
docs: correct a typo in the usage doc

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -3,7 +3,11 @@ Usage
 
 The :py:func:`copie <pytest_copie.plugin.copie>` fixture will allow you to :py:meth:`copy <pytest_copie.plugin.Copy.copy>` a template and run tests against it. It will also clean up the generated project after the tests have been run.
 
-For these examples, let's assume the current folder is a copier template. it should include a ``copier.yml`` file and a ``{{repo_name}}`` folder containing jinja templates.
+For these examples, let's assume the current folder is a copier template. it should include a ``copier.yml`` file and a ``template`` folder containing jinja templates.
+
+.. note::
+
+   The name of the templlate folder can be anything as long as it matches the ``_subdirectory`` key in the ``copier.yml`` file.
 
 .. code-block::
 


### PR DESCRIPTION
the mention to {{ repo_name}} is a legacy from the previous implementation based on pytest-cookies that is not compatible with copier itself. 