### PR TITLE
fix: always use the HEAD in the tests

### DIFF
--- a/pytest_copie/plugin.py
+++ b/pytest_copie/plugin.py
@@ -86,6 +86,7 @@ class Copie:
                 unsafe=True,
                 defaults=True,
                 user_defaults=extra_answers,
+                vcs_ref="HEAD",
             )
 
             # refresh project_dir with the generated one


### PR DESCRIPTION
In some tests I was not able to check the latest modification because copier was trying to reach latest available TAG instead of head branch. This is a tentative of fix by simply specifying that the vcs-ref of the Worker should always be HEAD.

This problem should only be visible to templates using versioning