### PR TITLE
Support for `copier.yaml` files that include other files

### DIFF
--- a/pytest_copie/plugin.py
+++ b/pytest_copie/plugin.py
@@ -71,8 +71,10 @@ class Copie:
         try:
 
             # make sure the copiercopier project is using subdirectories
-            params = yaml.safe_load(copier_yaml.read_text())
-            if "_subdirectory" not in params:
+            _add_yaml_include_constructor()
+
+            all_params = yaml.safe_load_all(copier_yaml.read_text())
+            if not any("_subdirectory" in params for params in all_params):
                 raise ValueError(
                     "The plugin can only work for templates using subdirectories, "
                     '"_subdirectory" key is missing from copier.yaml'
@@ -172,3 +174,21 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     """Force the template path to be absolute to protect ourselves from fixtures that changes path."""
     config.option.template = str(Path(config.option.template).resolve())
+
+
+def _add_yaml_include_constructor():
+    """Adds an include constructor to yaml.SafeLoader."""
+
+    def include_constructor(
+        loader: yaml.SafeLoader,
+        node: yaml.Node,
+    ):
+        fullpath = Path.cwd() / node.value
+
+        if not fullpath.is_file():
+            raise FileNotFoundError(f"The filename '{fullpath}' does not exist.")
+
+        with fullpath.open("rb") as f:
+            return yaml.safe_load(f)
+
+    yaml.add_constructor("!include", include_constructor, yaml.SafeLoader)

--- a/pytest_copie/plugin.py
+++ b/pytest_copie/plugin.py
@@ -71,7 +71,7 @@ class Copie:
         try:
 
             # make sure the copiercopier project is using subdirectories
-            _add_yaml_include_constructor()
+            _add_yaml_include_constructor(template_dir)
 
             all_params = yaml.safe_load_all(copier_yaml.read_text())
             if not any("_subdirectory" in params for params in all_params):
@@ -176,14 +176,16 @@ def pytest_configure(config):
     config.option.template = str(Path(config.option.template).resolve())
 
 
-def _add_yaml_include_constructor():
+def _add_yaml_include_constructor(
+    template_dir: Path,
+):
     """Adds an include constructor to yaml.SafeLoader."""
 
     def include_constructor(
         loader: yaml.SafeLoader,
         node: yaml.Node,
     ):
-        fullpath = Path.cwd() / node.value
+        fullpath = template_dir / node.value
 
         if not fullpath.is_file():
             raise FileNotFoundError(f"The filename '{fullpath}' does not exist.")

--- a/tests/test_copie.py
+++ b/tests/test_copie.py
@@ -210,98 +210,96 @@ def test_config(testdir, test_check):
     assert result.ret == 0
 
 
-class TestInclude:
-    """Tests the '!include' directive supported by copier."""
+def test_copy_include_file(testdir):
+    """Validates that pytest-copie can handle the '!include' directive."""
+    (template_dir := Path(testdir.tmpdir) / "copie-template").mkdir()
 
-    def test_working(self, testdir):
-        """Validates that pytest-copie can handle the '!include' directive."""
-        (template_dir := Path(testdir.tmpdir) / "copie-template").mkdir()
+    (template_dir / "copier.yml").write_text(
+        textwrap.dedent(
+            """\
+            test1: test1
 
-        (template_dir / "copier.yml").write_text(
-            textwrap.dedent(
-                """\
-                test1: test1
+            ---
+            !include other.yml
+            ---
 
-                ---
-                !include other.yml
-                ---
+            test2: test2
 
-                test2: test2
-
-                _subdirectory: project
-                """,
-            ),
-        )
-
-        (template_dir / "other.yml").write_text(
-            textwrap.dedent(
-                """\
-                test3: test3
-                """,
-            ),
-        )
-
-        (repo_dir := template_dir / "project").mkdir()
-
-        (repo_dir / "README.rst.jinja").write_text(
-            textwrap.dedent(
-                """\
-                test1: {{ test1 }}
-                test2: {{ test2 }}
-                test3: {{ test3 }}
-                """,
-            ),
-        )
-
-        testdir.makepyfile(
-            """
-            def test_copie_project(copie):
-                result = copie.copy()
-
-                assert result.exit_code == 0
-                assert result.exception is None
-
-                readme_file = result.project_dir / "README.rst"
-                assert readme_file.read_text() == "test1: test1\\ntest2: test2\\ntest3: test3\\n"
-            """
-        )
-
-        result = testdir.runpytest("-v", f"--template={template_dir}")
-        assert result.ret == 0
-
-    def test_error_invalid_include_file(self, testdir):
-        """Validates that pytest-copie raises an exception when the included file does not exist."""
-        (template_dir := Path(testdir.tmpdir) / "copie-template").mkdir()
-
-        (template_dir / "copier.yml").write_text(
-            textwrap.dedent(
-                """\
-                test1: test1
-
-                ---
-                !include file_does_not_exist.yml
-                ---
-
-                test2: test2
-
-                _subdirectory: project
-                """,
-            ),
-        )
-
-        invalid_filename = template_dir / "file_does_not_exist.yml"
-        invalid_filename_str = str(invalid_filename).replace("\\", "\\\\")
-
-        testdir.makepyfile(
-            f"""
-            def test_copie_project(copie):
-                result = copie.copy()
-
-                assert result.exit_code == -1
-                assert result.exception is not None
-                assert str(result.exception) == "The filename '{invalid_filename_str}' does not exist."
+            _subdirectory: project
             """,
-        )
+        ),
+    )
 
-        result = testdir.runpytest("-v", f"--template={template_dir}")
-        assert result.ret == 0
+    (template_dir / "other.yml").write_text(
+        textwrap.dedent(
+            """\
+            test3: test3
+            """,
+        ),
+    )
+
+    (repo_dir := template_dir / "project").mkdir()
+
+    (repo_dir / "README.rst.jinja").write_text(
+        textwrap.dedent(
+            """\
+            test1: {{ test1 }}
+            test2: {{ test2 }}
+            test3: {{ test3 }}
+            """,
+        ),
+    )
+
+    testdir.makepyfile(
+        """
+        def test_copie_project(copie):
+            result = copie.copy()
+
+            assert result.exit_code == 0
+            assert result.exception is None
+
+            readme_file = result.project_dir / "README.rst"
+            assert readme_file.read_text() == "test1: test1\\ntest2: test2\\ntest3: test3\\n"
+        """
+    )
+
+    result = testdir.runpytest("-v", f"--template={template_dir}")
+    assert result.ret == 0
+
+
+def test_copy_include_file_error_invalid_file(testdir):
+    """Validates that pytest-copie raises an exception when the included file does not exist."""
+    (template_dir := Path(testdir.tmpdir) / "copie-template").mkdir()
+
+    (template_dir / "copier.yml").write_text(
+        textwrap.dedent(
+            """\
+            test1: test1
+
+            ---
+            !include file_does_not_exist.yml
+            ---
+
+            test2: test2
+
+            _subdirectory: project
+            """,
+        ),
+    )
+
+    invalid_filename = template_dir / "file_does_not_exist.yml"
+    invalid_filename_str = str(invalid_filename).replace("\\", "\\\\")
+
+    testdir.makepyfile(
+        f"""
+        def test_copie_project(copie):
+            result = copie.copy()
+
+            assert result.exit_code == -1
+            assert result.exception is not None
+            assert str(result.exception) == "The filename '{invalid_filename_str}' does not exist."
+        """,
+    )
+
+    result = testdir.runpytest("-v", f"--template={template_dir}")
+    assert result.ret == 0


### PR DESCRIPTION
copier configuration files can include other files ([more info here](https://copier.readthedocs.io/en/stable/configuring/#include-other-yaml-files)).

This change adds support for those files by using `yaml.safe_load_all` to load the yaml content rather than `yaml.safe_load`. It also includes functionality to support `!include`.