### PR TITLE
Spell fix: templlate -> template

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -7,7 +7,7 @@ For these examples, let's assume the current folder is a copier template. it sho
 
 .. note::
 
-   The name of the templlate folder can be anything as long as it matches the ``_subdirectory`` key in the ``copier.yml`` file.
+   The name of the template folder can be anything as long as it matches the ``_subdirectory`` key in the ``copier.yml`` file.
 
 .. code-block::
 


### PR DESCRIPTION
Found this little spell error [here](https://github.com/12rambau/pytest-copie/blob/main/docs/usage.rst) at line 10.