### PR TITLE
docs: update installation directives

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -12,3 +12,9 @@ Alternatively it is also available on `conda-forge <https://anaconda.org/conda-f
 .. code-block:: console
 
     conda install pytest-copie
+
+.. warning:: 
+
+    `pytest` is loading all the existing plugin from the running environment which is a super powerfull feature of the framework. As this is a port of `pytest-cookies`, 
+    the 2 plugin will conflict with one another if installed in together as reported in https://github.com/12rambau/pytest-copie/issues/85. We highly recomend to run your tests
+    in dedicated environements siloted from one another.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -13,8 +13,8 @@ Alternatively it is also available on `conda-forge <https://anaconda.org/conda-f
 
     conda install pytest-copie
 
-.. warning:: 
+.. warning::
 
-    `pytest` is loading all the existing plugin from the running environment which is a super powerfull feature of the framework. As this is a port of `pytest-cookies`, 
-    the 2 plugin will conflict with one another if installed in together as reported in https://github.com/12rambau/pytest-copie/issues/85. We highly recomend to run your tests
+    `pytest` is loading all the existing plugin from the running environment which is a super powerful feature of the framework. As this is a port of `pytest-cookies`,
+    the 2 plugin will conflict with one another if installed in together as reported in https://github.com/12rambau/pytest-copie/issues/85. We highly recommend to run your tests
     in dedicated environements siloted from one another.


### PR DESCRIPTION
Fix: https://github.com/12rambau/pytest-copie/issues/85

As mentioned in the linked issue, the mother plugin of this package is conflicting with `pytest-copie` when the 2 of them are installed in the same environement. 