### PR TITLE
Don't reuse mutable default parameter

### DIFF
--- a/pytest_copie/plugin.py
+++ b/pytest_copie/plugin.py
@@ -126,7 +126,9 @@ class Copie:
         except Exception as e:
             return Result(exception=e, exit_code=-1)
 
-    def update(self, result: Result, extra_answers: dict = {}, vcs_ref: str = "HEAD") -> Result:
+    def update(
+        self, result: Result, extra_answers: Optional[dict] = None, vcs_ref: str = "HEAD"
+    ) -> Result:
         """Update a copier Project from the template and return the associated :py:class:`Result <pytest_copie.plugin.Result>` object, returns a new :py:class:`Result <pytest_copie.plugin.Result>`.
 
         Args:
@@ -147,7 +149,7 @@ class Copie:
                 unsafe=True,
                 defaults=True,
                 overwrite=True,
-                user_defaults=extra_answers,
+                user_defaults=extra_answers if extra_answers is not None else {},
                 vcs_ref=vcs_ref,
             )
 


### PR DESCRIPTION
Thanks to the work done in https://github.com/12rambau/pytest-copie/pull/95, updating is now supported as well.

The parameter `extra_answers` is declared and initialized as a dict inside the function's signature though, which means it will be reused between invocations. This might not be a problem depending on what `copier.run_update` does with it, but it's still smelly code.

This ensures a fresh, empty dict is passed to Copier when `Copie.update` is called without the `extra_answers` parameter.